### PR TITLE
Windows `import` fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@buidlerlabs/hashgraph-venin-js",
-  "version": "0.8.2-beta.0",
+  "version": "0.8.2-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@buidlerlabs/hashgraph-venin-js",
-      "version": "0.8.2-beta.0",
+      "version": "0.8.2-beta.1",
       "license": "MIT",
       "dependencies": {
         "@ethersproject/abi": "^5.5.0",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "url": "https://github.com/buidler-labs/hashgraph-venin-js"
   },
   "types": "./types/index.d.ts",
-  "version": "0.8.2-beta.0",
+  "version": "0.8.2-beta.1",
   "peerDependencies": {
     "@hashgraph/sdk": "~2.17.1"
   }


### PR DESCRIPTION
Bumped version to `0.8.2-beta.1`.

All tests are green.

Closes #131 